### PR TITLE
Cancelling orders on closed markets

### DIFF
--- a/frontend/client/style/style.scss
+++ b/frontend/client/style/style.scss
@@ -1656,13 +1656,7 @@ table {
             width: 100%;
             @for $i from 1 through $max {
               @include qq-equal(5) {
-                max-width: 120px;
-                &:first-of-type {
-                  width: 0px;
-                } 
-                &:last-of-type {
-                  width: 0px;
-                }                                
+                max-width: 110px;
               }
               @include qq-equal(6) {
                 max-width: 75px;
@@ -1738,13 +1732,7 @@ table {
             width: 100%;
             @for $i from 1 through $max {
               @include qq-equal(5) {
-                max-width: 120px;
-                &:first-of-type {
-                  width: 0px;
-                } 
-                &:last-of-type {
-                  width: 0px;
-                }                                
+                max-width: 110px;
               }
               @include qq-equal(6) {
                 max-width: 75px;

--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -71,6 +71,10 @@ Offers.helpers(_.extend(helpers, {
     const address = Session.get('address');
     return this.status === Status.CONFIRMED && (!marketOpen || address === this.owner);
   },
+  isOurs() {
+    const address = Session.get('address');
+    return (address === this.owner);
+  },
 }));
 
 Trades.helpers(helpers);

--- a/frontend/imports/ui/client/widgets/maintrades.html
+++ b/frontend/imports/ui/client/widgets/maintrades.html
@@ -36,10 +36,10 @@
   <div class="row">
     <div class="order-center">
       <section class="order-section col-md-6">
-        {{> orderbook title='BUY ORDERS' subtitle=(concat '(click on an order listing to sell ' baseCurrency ')') priceClass='bid' priceLabel='BID PRICE' orders=(findOffers 'bid') canAccept=true showType=false}}
+        {{> orderbook title='BUY ORDERS' subtitle=(concat '(click on an order listing to sell ' baseCurrency ')') priceClass='bid' priceLabel='BID PRICE' orders=(findOffers 'bid') showType=false}}
       </section>
       <section class="order-section col-md-6">
-        {{> orderbook title='SELL ORDERS' subtitle=(concat '(click on an order listing to buy ' baseCurrency ')') priceClass='ask' priceLabel='ASK PRICE' orders=(findOffers 'ask') canAccept=true}}
+        {{> orderbook title='SELL ORDERS' subtitle=(concat '(click on an order listing to buy ' baseCurrency ')') priceClass='ask' priceLabel='ASK PRICE' orders=(findOffers 'ask')}}
       </section>
     </div>
   </div>

--- a/frontend/imports/ui/client/widgets/offermodal.html
+++ b/frontend/imports/ui/client/widgets/offermodal.html
@@ -148,12 +148,20 @@
             {{#if offer}}
               <span class="text-danger">
                 {{#if equals offer.type 'bid'}}
-                  This action will return {{{formatBalance (offer.volume quoteCurrency) '' '' true}}} {{quoteCurrency}} {{formatPrice (offer.volume quoteCurrency) quoteCurrency}} to your token balance.
+                  This action will return {{{formatBalance (offer.volume quoteCurrency) '' '' true}}} {{quoteCurrency}} {{formatPrice (offer.volume quoteCurrency) quoteCurrency}}
                 {{else}}
-                  This action will return {{{formatBalance (offer.volume baseCurrency) '' '' true}}} {{baseCurrency}} {{formatPrice (offer.volume baseCurrency) baseCurrency}} to your token balance.
+                  This action will return {{{formatBalance (offer.volume baseCurrency) '' '' true}}} {{baseCurrency}} {{formatPrice (offer.volume baseCurrency) baseCurrency}}
                 {{/if}}
-                <br>
-                If someone (partially) fills this order before you cancel it, your order may not or only be partially cancelled.
+                to
+                {{#if offer.isOurs}}
+                  your token balance.
+                {{else}}
+                  the token balance of its owner.
+                {{/if}}
+                {{#if isMarketOpen}}
+                  <br>
+                  If someone (partially) fills this order before you cancel it, your order may not or only be partially cancelled.
+                {{/if}}
               </span>
             {{/if}}
           </div>

--- a/frontend/imports/ui/client/widgets/offermodal.html
+++ b/frontend/imports/ui/client/widgets/offermodal.html
@@ -160,6 +160,7 @@
                 {{/if}}
                 {{#if isMarketOpen}}
                   <br>
+                  <br>
                   If someone (partially) fills this order before you cancel it, your order may not or only be partially cancelled.
                 {{/if}}
               </span>

--- a/frontend/imports/ui/client/widgets/orderbook.html
+++ b/frontend/imports/ui/client/widgets/orderbook.html
@@ -6,7 +6,7 @@
       {{> whatisthis section="orderbook"}}
     </h2>
     <div>  
-      {{> orders orders=orders type=priceClass priceLabel=priceLabel priceClass=priceClass canAccept=canAccept showCancel=(not isMarketOpen)}}
+      {{> orders orders=orders type=priceClass priceLabel=priceLabel priceClass=priceClass canAccept=(isMarketOpen) showCancel=(not isMarketOpen)}}
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fixes #179.

The cancel button was visible in the "BUY ORDERS" and "SELL ORDERS" sections for closed markets, but clicking it didn't work. I fixed the stylesheet in order to make it clickable. Fixing it surfaced some other problems as well: accepting orders was possible on closed markets (so it was conflicting with the cancel button) and the messages in the order cancellation window did not really make sense in case of closed markets. I did fix the former and also made the messages conditional so they fit both cases now.