### PR TITLE
Fixing typo frontent/.meteor/ -> frontend/.meteor/

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ],
     "ignore": [
       "dapple_packages/**",
-      "frontent/.meteor/**",
+      "frontend/.meteor/**",
       "frontend/packages/**",
       "scripts/**"
     ]


### PR DESCRIPTION
Looks like a typo: The folder name fronten**t**/.meteor/