### PR TITLE
Hiding dust orders

### DIFF
--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -30,9 +30,6 @@ Session.set('lastTradesLimit', TRADES_LIMIT);
 const OFFER_LIMIT = 0;
 Session.set('orderBookLimit', OFFER_LIMIT);
 
-const DUST_LIMIT = {"W-ETH": 1000000000000000};
-Session.set('orderBookDustLimit', DUST_LIMIT);
-
 const helpers = {
   volume(currency) {
     let volume = '0';

--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -30,6 +30,9 @@ Session.set('lastTradesLimit', TRADES_LIMIT);
 const OFFER_LIMIT = 0;
 Session.set('orderBookLimit', OFFER_LIMIT);
 
+const DUST_LIMIT = {"W-ETH": 1000000000000000};
+Session.set('orderBookDustLimit', DUST_LIMIT);
+
 const helpers = {
   volume(currency) {
     let volume = '0';
@@ -260,6 +263,8 @@ Offers.updateOffer = (idx, sellHowMuch, sellWhichTokenAddress, buyHowMuch, buyWh
       sellWhichToken: sellToken,
       buyHowMuch: buyHowMuchValue.valueOf(),
       sellHowMuch: sellHowMuchValue.valueOf(),
+      buyHowMuch_filter: buyHowMuchValue.toNumber(),
+      sellHowMuch_filter: sellHowMuchValue.toNumber(),
       ask_price: buyHowMuchValue.div(sellHowMuchValue).valueOf(),
       bid_price: sellHowMuchValue.div(buyHowMuchValue).valueOf(),
       ask_price_sort: buyHowMuchValue.div(sellHowMuchValue).toNumber(),

--- a/frontend/imports/startup/client/network.js
+++ b/frontend/imports/startup/client/network.js
@@ -143,6 +143,8 @@ function initSession() {
   if (!Session.get('volumeSelector')) {
     Session.set('volumeSelector', 'quote');
   }
+
+  Session.set('orderBookDustLimit', {"W-ETH": 1000000000000000});
 }
 
 /**

--- a/frontend/imports/ui/client/helpers.js
+++ b/frontend/imports/ui/client/helpers.js
@@ -122,13 +122,13 @@ Template.registerHelper('lastTrades', () => {
 Template.registerHelper('countOffers', (type) => {
   const quoteCurrency = Session.get('quoteCurrency');
   const baseCurrency = Session.get('baseCurrency');
-  const options = {};
-  options.sort = { ask_price_sort: 1 };
+  const dustLimitMap = Session.get('orderBookDustLimit');
+  const dustLimit = dustLimitMap[quoteCurrency] ? dustLimitMap[quoteCurrency] : 0;
 
   if (type === 'ask') {
-    return Offers.find({ buyWhichToken: quoteCurrency, sellWhichToken: baseCurrency }, options).count();
+    return Offers.find({ buyWhichToken: quoteCurrency, sellWhichToken: baseCurrency, buyHowMuch_filter: {$gte: dustLimit} }).count();
   } else if (type === 'bid') {
-    return Offers.find({ buyWhichToken: baseCurrency, sellWhichToken: quoteCurrency }, options).count();
+    return Offers.find({ buyWhichToken: baseCurrency, sellWhichToken: quoteCurrency, sellHowMuch_filter: {$gte: dustLimit} }).count();
   }
   return 0;
 });
@@ -137,6 +137,8 @@ Template.registerHelper('findOffers', (type) => {
   const quoteCurrency = Session.get('quoteCurrency');
   const baseCurrency = Session.get('baseCurrency');
   const limit = Session.get('orderBookLimit');
+  const dustLimitMap = Session.get('orderBookDustLimit');
+  const dustLimit = dustLimitMap[quoteCurrency] ? dustLimitMap[quoteCurrency] : 0;
 
   const options = {};
   options.sort = { ask_price_sort: 1 };
@@ -145,9 +147,9 @@ Template.registerHelper('findOffers', (type) => {
   }
 
   if (type === 'ask') {
-    return Offers.find({ buyWhichToken: quoteCurrency, sellWhichToken: baseCurrency }, options);
+    return Offers.find({ buyWhichToken: quoteCurrency, sellWhichToken: baseCurrency, buyHowMuch_filter: {$gte: dustLimit} }, options);
   } else if (type === 'bid') {
-    return Offers.find({ buyWhichToken: baseCurrency, sellWhichToken: quoteCurrency }, options);
+    return Offers.find({ buyWhichToken: baseCurrency, sellWhichToken: quoteCurrency, sellHowMuch_filter: {$gte: dustLimit} }, options);
   } else if (type === 'mine') {
     const or = [
       { buyWhichToken: quoteCurrency, sellWhichToken: baseCurrency },


### PR DESCRIPTION
Hiding orders below a certain threshold in the "BUY ORDERS" and "SELL ORDERS" sections. The "MY ORDERS" section still shows all orders submitted by us, even if they are below that threshold.

The threshold is defined per currency (although I presume it's only W-ETH currently) and is hardcoded for now. I've set it to 0.001 W-ETH.

In order to implement collection filtering efficiently I had to store 'buyHowMuch' and 'sellHowMuch' fields as numbers as well ie. by creating two additional fields in the Offer document. It doesn't give us perfect precision, but it's for filtering only so should be ok. The same trick is already being used for
sorting as well.