### PR TITLE
Completely disabled buy and sell controls for closed markets

### DIFF
--- a/frontend/client/style/style.scss
+++ b/frontend/client/style/style.scss
@@ -897,7 +897,6 @@ table {
         td {
           &.available {
             span.fill-amount {
-              cursor: pointer;
               opacity: 0.68;
               font-family: 'Roboto';
               font-weight: 500;
@@ -905,6 +904,9 @@ table {
               color: #222228;
               text-align: right;
               padding-right: 10px;
+              &.clickable {
+                cursor: pointer;
+              }
             }            
           }
         }

--- a/frontend/imports/ui/client/widgets/neworder.html
+++ b/frontend/imports/ui/client/widgets/neworder.html
@@ -13,9 +13,9 @@
             </th>
             <td class="available">
               {{#if equals type 'buy'}}
-              <span class="fill-amount" {{b "click: autofill"}}>{{{formatBalance quoteAvailable '' '' true}}}</span> <span class="span-buy-sell-currency">{{quoteCurrency}}</span>
+              <span class="fill-amount {{#if canAutofill}}clickable{{/if}}" {{b "click: autofill"}}>{{{formatBalance quoteAvailable '' '' true}}}</span> <span class="span-buy-sell-currency">{{quoteCurrency}}</span>
               {{else}}
-              <span class="fill-amount" {{b "click: autofill"}}>{{{formatBalance baseAvailable '' '' true}}}</span> <span class="span-buy-sell-currency">{{baseCurrency}}</span>
+              <span class="fill-amount {{#if canAutofill}}clickable{{/if}}" {{b "click: autofill"}}>{{{formatBalance baseAvailable '' '' true}}}</span> <span class="span-buy-sell-currency">{{baseCurrency}}</span>
               {{/if}}
             </td>
           </tr>
@@ -24,7 +24,7 @@
               PRICE
             </th>
             <td>
-              <input type="number" class="input" step="any" min="0" {{b "value: price, input: calcTotal"}}> <span class="span-buy-sell-currency">{{quoteCurrency}}</span>
+              <input type="number" class="input" step="any" min="0" {{b "value: price, input: calcTotal, enable: canChangePrice"}}> <span class="span-buy-sell-currency">{{quoteCurrency}}</span>
             </td>
           </tr>
           <tr class="row-input-line">
@@ -32,7 +32,7 @@
               AMOUNT
             </th>
             <td>
-              <input type="number" class="input" step="any" min="0" {{b "value: amount, input: calcTotal, enable: priceDefined, attr: { max: maxAmount }"}}> <span class="span-buy-sell-currency">{{baseCurrency}}</span>
+              <input type="number" class="input" step="any" min="0" {{b "value: amount, input: calcTotal, enable: canChangeAmountAndTotal, attr: { max: maxAmount }"}}> <span class="span-buy-sell-currency">{{baseCurrency}}</span>
             </td>
           </tr>
           <tr class="row-input-line">
@@ -40,7 +40,7 @@
               TOTAL
             </th>
             <td>
-              <input type="number" class="input" step="any" min="0" {{b "value: total, input: calcAmount, enable: priceDefined, attr: { max: maxTotal }"}}> <span class="span-buy-sell-currency">{{quoteCurrency}}</span>
+              <input type="number" class="input" step="any" min="0" {{b "value: total, input: calcAmount, enable: canChangeAmountAndTotal, attr: { max: maxTotal }"}}> <span class="span-buy-sell-currency">{{quoteCurrency}}</span>
             </td>
           </tr>
         </tbody>
@@ -49,7 +49,7 @@
         <tr>
           <td class="first-row">
             {{#if isMarketOpen}}
-              {{#unless priceDefined}}
+              {{#unless canChangeAmountAndTotal}}
                 <span class="help-block">Enter a price to unlock amount and total.</span>
               {{/unless}}
               {{#unless validAmount}}

--- a/frontend/imports/ui/client/widgets/neworder.js
+++ b/frontend/imports/ui/client/widgets/neworder.js
@@ -30,7 +30,15 @@ Template.neworder.viewmodel({
     return Session.get('baseCurrency');
   },
   price: '0',
-  priceDefined() {
+  canAutofill() {
+    return Session.get('market_open');
+  },
+  canChangePrice() {
+    return Session.get('market_open');
+  },
+  canChangeAmountAndTotal() {
+    const marketOpen = Session.get('market_open');
+    if (!marketOpen) return false;
     try {
       const price = new BigNumber(this.price());
       return !price.isNaN() && price.gt(0);
@@ -228,11 +236,13 @@ Template.neworder.viewmodel({
     return undefined;
   },
   autofill() {
+    const marketOpen = Session.get('market_open');
     const quoteCurrency = Session.get('quoteCurrency');
     const baseCurrency = Session.get('baseCurrency');
     let offer;
     let price = 0;
     let available = 0;
+    if (!marketOpen) return false;
     if (this.type() === 'buy') {
       offer = Offers.findOne({ buyWhichToken: quoteCurrency, sellWhichToken: baseCurrency },
                               { sort: { ask_price_sort: 1 } });


### PR DESCRIPTION
Even for closed markets you could still call autofill by clicking on the available amount and edit amounts & prices in the buy and sell sections. This change completely blocks these controls for closed markets.

This pull request completely resolves #181.