### PR TITLE
Fixed broken table layour for orderbook when scrollbar visible

### DIFF
--- a/frontend/client/style/style.scss
+++ b/frontend/client/style/style.scss
@@ -1657,6 +1657,9 @@ table {
             @for $i from 1 through $max {
               @include qq-equal(5) {
                 max-width: 110px;
+                &:last-of-type {
+                  width: 0px;
+                }
               }
               @include qq-equal(6) {
                 max-width: 75px;
@@ -1733,6 +1736,9 @@ table {
             @for $i from 1 through $max {
               @include qq-equal(5) {
                 max-width: 110px;
+                &:last-of-type {
+                  width: 0px;
+                }
               }
               @include qq-equal(6) {
                 max-width: 75px;


### PR DESCRIPTION
Trying to fix cancelling orders on closed markets, I accidentally broke table layour for the orderbook. Unnoticed by me as I tested with less than 5 orders.