### PR TITLE
Changed the order calcellation helper wording

### DIFF
--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -316,7 +316,7 @@ Offers.cancelOffer = (idx) => {
   Dapple['maker-otc'].objects.otc.cancel(id, { gas: CANCEL_GAS }, (error, tx) => {
     if (!error) {
       Transactions.add('offer', tx, { id: idx, status: Status.CANCELLED });
-      Offers.update(idx, { $set: { tx, status: Status.CANCELLED, helper: 'Your order is being cancelled...' } });
+      Offers.update(idx, { $set: { tx, status: Status.CANCELLED, helper: 'The order is being cancelled...' } });
     } else {
       Offers.update(idx, { $set: { helper: formatError(error) } });
     }


### PR DESCRIPTION
As you can cancel not just your own orders (eg. in case of closed markets), changed the wording of the helper message to be generic.