### PR TITLE
Historical trades fetching

### DIFF
--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -105,6 +105,7 @@ Offers.getHistoricalTradesRange = (numberOfPreviousDays) => {
     return Offers.getBlock('latest').then((block) => block.number);
   }
   function getBlockNumberOfSomeBlockEarlierThan(timestamp, startingFrom) {
+    if (startingFrom < 0) return Promise.resolve(0);
     return Offers.getBlock(startingFrom).then((block) => {
       if (block.timestamp*1000 <= timestamp) {
         return block.number;

--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -110,7 +110,7 @@ Offers.getHistoricalTradesRange = (numberOfPreviousDays) => {
         return block.number;
       }
       else {
-        return getBlockNumberOfSomeBlockEarlierThan(startingFrom-STEP_NUMBER_OF_BLOCKS_BACKWARDS, timestamp);
+        return getBlockNumberOfSomeBlockEarlierThan(timestamp, startingFrom-STEP_NUMBER_OF_BLOCKS_BACKWARDS);
       }
     });
   }

--- a/frontend/imports/api/offers.js
+++ b/frontend/imports/api/offers.js
@@ -93,10 +93,51 @@ Offers.checkMarketOpen = () => {
   });
 };
 
+// As it is expensive to load historical Trades, we load them only for the last week
+// Enough for the Volume chart and the Market History section
+Offers.getHistoricalTradesRange = (numberOfPreviousDays) => {
+  // 5760 is an average number of blocks per day. in case we didn't get far enough
+  // after the initial jump we step back 1000 blocks at a time
+  const INITIAL_NUMBER_OF_BLOCKS_BACKWARDS = 5760*(numberOfPreviousDays+1)+3000;
+  const STEP_NUMBER_OF_BLOCKS_BACKWARDS = 1000;
+
+  function getBlockNumberOfTheMostRecentBlock() {
+    return Offers.getBlock('latest').then((block) => block.number);
+  }
+  function getBlockNumberOfSomeBlockEarlierThan(timestamp, startingFrom) {
+    return Offers.getBlock(startingFrom).then((block) => {
+      if (block.timestamp*1000 <= timestamp) {
+        return block.number;
+      }
+      else {
+        return getBlockNumberOfSomeBlockEarlierThan(startingFrom-STEP_NUMBER_OF_BLOCKS_BACKWARDS, timestamp);
+      }
+    });
+  }
+
+  return getBlockNumberOfTheMostRecentBlock().then((blockNumberOfTheMostRecentBlock) => {
+    const startTimestamp = moment(Date.now()).startOf('day').subtract(numberOfPreviousDays, 'days');
+    const initialGuess = blockNumberOfTheMostRecentBlock-INITIAL_NUMBER_OF_BLOCKS_BACKWARDS;
+    return getBlockNumberOfSomeBlockEarlierThan(startTimestamp, initialGuess).then((foundBlockNumber) => {
+        return {
+            startBlockNumber: foundBlockNumber,
+            startTimestamp: startTimestamp,
+            endBlockNumber: blockNumberOfTheMostRecentBlock
+        };
+    });
+  });
+};
+
 /**
  * Syncs up all offers and trades
  */
 Offers.sync = () => {
+  Offers.checkMarketOpen();
+  Offers.syncOffers();
+  Offers.getHistoricalTradesRange(6).then(Offers.syncTrades);
+};
+
+Offers.syncOffers = () => {
   Offers.remove({});
 
   // Watch ItemUpdate Event
@@ -111,8 +152,6 @@ Offers.sync = () => {
       }
     }
   });
-
-  Offers.checkMarketOpen();
 
   // Sync all past offers
   Dapple['maker-otc'].objects.otc.last_offer_id((error, n) => {
@@ -131,7 +170,9 @@ Offers.sync = () => {
       }
     }
   });
+};
 
+Offers.syncTrades = (historicalTradesRange) => {
   function transformArgs(trade) {
     const buyWhichToken = Dapple.getTokenByAddress(trade.args.buy_which_token);
     const sellWhichToken = Dapple.getTokenByAddress(trade.args.sell_which_token);
@@ -153,7 +194,8 @@ Offers.sync = () => {
 
 
   // Get all Trade events in one go so we can fill up prices, volume and history
-  Dapple['maker-otc'].objects.otc.Trade({}, { fromBlock: Dapple.getFirstContractBlock() }).get((error, trades) => {
+  Dapple['maker-otc'].objects.otc.Trade({}, { fromBlock: historicalTradesRange.startBlockNumber,
+    toBlock: historicalTradesRange.endBlockNumber }).get((error, trades) => {
     if (!error) {
       let trade = null;
       const promises = [];
@@ -168,7 +210,7 @@ Offers.sync = () => {
             trade = trades[i];
             const args = transformArgs(trade);
 
-            if (args) {
+            if (args && (resultProm[i].timestamp*1000 >= historicalTradesRange.startTimestamp)) {
               Trades.upsert(trade.transactionHash, _.extend(resultProm[i], trade, args));
             }
           }
@@ -181,7 +223,7 @@ Offers.sync = () => {
   });
 
   // Watch Trade events in realtime
-  Dapple['maker-otc'].objects.otc.Trade({}, { fromBlock: Session.get('startingBlock') }, (error, trade) => {
+  Dapple['maker-otc'].objects.otc.Trade({}, { fromBlock: historicalTradesRange.endBlockNumber+1 }, (error, trade) => {
     if (!error) {
       const args = transformArgs(trade);
       if (args) {

--- a/frontend/packages/dapple/package-post-init.js
+++ b/frontend/packages/dapple/package-post-init.js
@@ -29,19 +29,6 @@ Dapple.init = function init(env) {
   }
 };
 
-// XXX generated blocknumbers, should use incremental lookback instead
-Dapple.getFirstContractBlock = () => {
-  let blockNumber = 0;
-  if (Dapple.env === 'live') {
-    blockNumber = 2100636;
-  } else if (Dapple.env === 'ropsten') {
-    blockNumber = 23612;
-  } else if (Dapple.env === 'morden') {
-    blockNumber = 1524881;
-  }
-  return blockNumber;
-};
-
 const tokens = {
   ropsten: {
     'W-ETH': '0xece9fa304cc965b00afc186f5d0281a00d3dbbfd',


### PR DESCRIPTION
In order to optimize OasisDEX Pro page load times, I have changed the Trade event fetching mechanism so we do fetch only the last weeks Trades.

In order to find the block range of Trades to be fetched, I did implement a simple lookback algorithm. Please be aware, that the 'startBlockNumber' could be a bit earlier than the beginning (midnight) of the first day we are interested in, so I did apply some additional filtering in the actual trade fetching in order to ignore the too-early ones.

This solves #196.