### PR TITLE
Separated the order cancellation modal from order placement modals

### DIFF
--- a/frontend/imports/startup/client/index.js
+++ b/frontend/imports/startup/client/index.js
@@ -1,5 +1,6 @@
 // Import to load these templates
 import '../../ui/client/widgets/depositbalance.js';
+import '../../ui/client/widgets/cancelmodal.js';
 import '../../ui/client/widgets/chart.js';
 import '../../ui/client/widgets/progressblock.js';
 import '../../ui/client/widgets/ethtokens.js';

--- a/frontend/imports/ui/client/widgets/cancelmodal.html
+++ b/frontend/imports/ui/client/widgets/cancelmodal.html
@@ -1,0 +1,45 @@
+<template name="cancelmodal">
+  <div class="modal fade" id="cancelModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content modal-order">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">Cancel Offer</h4>
+        </div>
+        <div class="modal-body row">
+          <div class="col-xs-1">
+            <img src="order-warning.svg" class="order-warning">
+          </div>
+          <div class="col-xs-11">
+            {{#if offer}}
+              <span class="text-danger">
+                {{#if equals offer.type 'bid'}}
+                  This action will return {{{formatBalance (offer.volume quoteCurrency) '' '' true}}} {{quoteCurrency}} {{formatPrice (offer.volume quoteCurrency) quoteCurrency}}
+                {{else}}
+                  This action will return {{{formatBalance (offer.volume baseCurrency) '' '' true}}} {{baseCurrency}} {{formatPrice (offer.volume baseCurrency) baseCurrency}}
+                {{/if}}
+                to
+                {{#if offer.isOurs}}
+                  your token balance.
+                {{else}}
+                  the token balance of its owner.
+                {{/if}}
+                {{#if isMarketOpen}}
+                  <br>
+                  <br>
+                  If someone (partially) fills this order before you cancel it, your order may not or only be partially cancelled.
+                {{/if}}
+              </span>
+            {{/if}}
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default btn-submit-order btn-placement-left" data-dismiss="modal">Close</button>
+          {{#if offer}}
+            <button type="button" class="btn btn-default btn-submit-order-sell sell btn-placement-right" data-dismiss="modal" disabled={{not offer.canCancel}} {{b "click: cancel"}}>Cancel Offer</button>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/imports/ui/client/widgets/cancelmodal.js
+++ b/frontend/imports/ui/client/widgets/cancelmodal.js
@@ -1,0 +1,14 @@
+import { Session } from 'meteor/session';
+import { Template } from 'meteor/templating';
+
+import { Offers } from '/imports/api/offers';
+
+import './cancelmodal.html';
+
+
+Template.cancelmodal.viewmodel({
+  cancel() {
+    const offerId = this.templateInstance.data.offer._id;
+    Offers.cancelOffer(offerId);
+  },
+});

--- a/frontend/imports/ui/client/widgets/maintrades.html
+++ b/frontend/imports/ui/client/widgets/maintrades.html
@@ -54,6 +54,7 @@
     </div>
   </div>
   {{> offermodal offer=(findOffer selectedOffer)}}
+  {{> cancelmodal offer=(findOffer selectedOffer)}}
   {{else}}
   <div class="row">
     <div class="col-md-12 text-center">

--- a/frontend/imports/ui/client/widgets/offermodal.html
+++ b/frontend/imports/ui/client/widgets/offermodal.html
@@ -133,50 +133,6 @@
     </div>
   </div>
 
-  <div class="modal fade" id="cancelModal" tabindex="-1" role="dialog">
-    <div class="modal-dialog">
-      <div class="modal-content modal-order">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title">Cancel Offer</h4>
-        </div>
-        <div class="modal-body row">
-          <div class="col-xs-1">
-            <img src="order-warning.svg" class="order-warning">
-          </div>
-          <div class="col-xs-11">
-            {{#if offer}}
-              <span class="text-danger">
-                {{#if equals offer.type 'bid'}}
-                  This action will return {{{formatBalance (offer.volume quoteCurrency) '' '' true}}} {{quoteCurrency}} {{formatPrice (offer.volume quoteCurrency) quoteCurrency}}
-                {{else}}
-                  This action will return {{{formatBalance (offer.volume baseCurrency) '' '' true}}} {{baseCurrency}} {{formatPrice (offer.volume baseCurrency) baseCurrency}}
-                {{/if}}
-                to
-                {{#if offer.isOurs}}
-                  your token balance.
-                {{else}}
-                  the token balance of its owner.
-                {{/if}}
-                {{#if isMarketOpen}}
-                  <br>
-                  <br>
-                  If someone (partially) fills this order before you cancel it, your order may not or only be partially cancelled.
-                {{/if}}
-              </span>
-            {{/if}}
-          </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default btn-submit-order btn-placement-left" data-dismiss="modal">Close</button>
-          {{#if offer}}
-            <button type="button" class="btn btn-default btn-submit-order-sell sell btn-placement-right" data-dismiss="modal" disabled={{not offer.canCancel}} {{b "click: cancel"}}>Cancel Offer</button>
-          {{/if}}
-        </div>
-      </div>
-    </div>
-  </div>
-  
   {{#if quoteToken}}
     {{> newallowance token=quoteToken}}
   {{/if}}

--- a/frontend/imports/ui/client/widgets/offermodal.js
+++ b/frontend/imports/ui/client/widgets/offermodal.js
@@ -246,10 +246,6 @@ Template.offermodal.viewmodel({
   dismiss(event) {
     $(event.target).closest('.modal').modal('hide');
   },
-  cancel() {
-    const offerId = this.templateInstance.data.offer._id;
-    Offers.cancelOffer(offerId);
-  },
   canBuy() {
     try {
       if (Template.currentData().offer.status !== Status.CONFIRMED) {


### PR DESCRIPTION
As above. The order cancellation modal didn't have much to do with order placement, but they shared a common template. Changed that by moving the order cancellation modal to a separate template.

This is a forerunner of a big order-matching change.