### PR TITLE
Predictable ordering of the order lists

### DIFF
--- a/frontend/imports/ui/client/helpers.js
+++ b/frontend/imports/ui/client/helpers.js
@@ -141,7 +141,7 @@ Template.registerHelper('findOffers', (type) => {
   const dustLimit = dustLimitMap[quoteCurrency] ? dustLimitMap[quoteCurrency] : 0;
 
   const options = {};
-  options.sort = { ask_price_sort: 1 };
+  options.sort = { ask_price_sort: 1, _id: -1 };
   if (limit) {
     options.limit = limit;
   }
@@ -156,7 +156,7 @@ Template.registerHelper('findOffers', (type) => {
       { buyWhichToken: baseCurrency, sellWhichToken: quoteCurrency },
     ];
     const address = Session.get('address');
-    return Offers.find({ owner: address, $or: or });
+    return Offers.find({ owner: address, $or: or }, { sort: { buyWhichToken: 1, _id: -1 } });
   }
   return [];
 });


### PR DESCRIPTION
In case of two orders with the same price, the ordering was unpredictable. It was even worse in case of own orders, as there was no ordering specified at all.

Fixes #185 