### PR TITLE
Chart: display x axis in linear scale

### DIFF
--- a/frontend/imports/ui/client/widgets/chart.js
+++ b/frontend/imports/ui/client/widgets/chart.js
@@ -125,7 +125,12 @@ Template.chart.viewmodel({
                 },
               }],
               xAxes: [{
+                type: 'linear',
+                position: 'bottom',
                 display: false,
+                ticks: {
+                  stepSize: 0.1
+                }
               }],
             },
           },
@@ -203,7 +208,9 @@ Template.chart.viewmodel({
           return -1;
         }
         return 1;
-      }));
+      }))
+      // Remove upper values so that the spread is seen at the middle
+      .filter(val => val <= askPrices[0] * 2);
 
       // Preparing arrays for graph
       const askAmountsGraph = [];


### PR DESCRIPTION
This way the price difference would correspond with the distance between the dots.

Before:
![image](https://cloud.githubusercontent.com/assets/653586/24069047/f0dd5b6a-0b7c-11e7-8168-7a7b6f0f1f66.png)

After:
![image](https://cloud.githubusercontent.com/assets/653586/24069099/9b7d7482-0b7e-11e7-80ff-42d27a1addbc.png)

Some values are cut from the top in order for the spread to be seen at the middle of the chart.