### PR TITLE
Temp. Reinstate pro.oasisdex.com

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,7 @@ gulp.task('build-meteor', function (cb) {
 
 // gh-pages
 gulp.task('deploy-gh-pages', function () {
-  require('fs').writeFileSync('./dist/CNAME', 'oasisdex.com');
+  require('fs').writeFileSync('./dist/CNAME', 'pro.oasisdex.com');
   return gulp.src('./dist/**/*')
     .pipe(ghPages())
 })


### PR DESCRIPTION
Cloudflare DNS is not updating correctly so the page appears down. Since this was the pro page before there's no reason not to re-enable the cname until Cloudflare issue is resolved.